### PR TITLE
feat: add graphiql form, get 'endpoint' and 'query' inputs, send request

### DIFF
--- a/src/api/get-graphql-data.tsx
+++ b/src/api/get-graphql-data.tsx
@@ -1,0 +1,22 @@
+export default async function getGraphQlData(endpoint: string, query?: string): Promise<unknown> {
+  const bodyQuery = query ? `query ${query}` : '';
+
+  // TODO specify data type to replace 'unknown'
+  let response: unknown;
+  await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: bodyQuery }),
+  })
+    .then((res: Response) => {
+      return res.json();
+    })
+    .then((data) => {
+      response = data;
+    })
+    .catch((error: Error) => error);
+
+  return response;
+}

--- a/src/app/[lang]/GRAPHQL/[base64endpoint]/[base64body]/page.tsx
+++ b/src/app/[lang]/GRAPHQL/[base64endpoint]/[base64body]/page.tsx
@@ -1,0 +1,15 @@
+import getGraphQlData from '@/api/get-graphql-data';
+import GraphiQlForm from '@/components/graphiql-form/graphiql-form';
+import { GraphQlUrlParams } from '@/types/graphql';
+import getDecodedStr from '@/utils/get-decoded-string';
+
+export default async function GraphiQlClient({ params }: { params: GraphQlUrlParams }): Promise<React.ReactNode> {
+  const endpoint = getDecodedStr(params.base64endpoint);
+  const query = getDecodedStr(params.base64body);
+
+  let response: unknown;
+  if (endpoint !== undefined && query !== undefined) response = await getGraphQlData(endpoint, query);
+  console.log('response:', response); // response will be passed as props later
+
+  return <GraphiQlForm params={params} />;
+}

--- a/src/app/[lang]/GRAPHQL/[base64endpoint]/page.tsx
+++ b/src/app/[lang]/GRAPHQL/[base64endpoint]/page.tsx
@@ -1,0 +1,14 @@
+import getGraphQlData from '@/api/get-graphql-data';
+import GraphiQlForm from '@/components/graphiql-form/graphiql-form';
+import { GraphQlUrlParams } from '@/types/graphql';
+import getDecodedStr from '@/utils/get-decoded-string';
+
+export default async function GraphiQlClient({ params }: { params: GraphQlUrlParams }): Promise<React.ReactNode> {
+  const endpoint = getDecodedStr(params.base64endpoint);
+
+  let response: unknown;
+  if (endpoint) response = await getGraphQlData(endpoint);
+  console.log('response:', response); // response will be passed as props later
+
+  return <GraphiQlForm params={params} />;
+}

--- a/src/app/[lang]/dictionaries/en.json
+++ b/src/app/[lang]/dictionaries/en.json
@@ -8,6 +8,10 @@
     "response": "Body"
   },
   "headers": "Headers",
+  "graphql": {
+    "endpointUrl": "Endpoint URL",
+    "query": "Query"
+  },
   "key": "Key",
   "method": "Method",
   "request": "Request",

--- a/src/app/[lang]/dictionaries/ru.json
+++ b/src/app/[lang]/dictionaries/ru.json
@@ -8,6 +8,10 @@
     "response": "Тело ответа"
   },
   "headers": "Заголовки",
+  "graphql": {
+    "endpointUrl": "URL-адрес",
+    "query": "Запрос (query)"
+  },
   "key": "Ключ",
   "method": "Метод",
   "request": "Запрос",

--- a/src/app/[lang]/globals.scss
+++ b/src/app/[lang]/globals.scss
@@ -3,6 +3,7 @@
   --table-text-color: #585858;
   --placeholder-color: #b9b9b9;
   --table-border: #d3d3d3;
+  --color-label: #8f8f8f;
 }
 
 * {

--- a/src/app/[lang]/graphiql/page.tsx
+++ b/src/app/[lang]/graphiql/page.tsx
@@ -1,0 +1,5 @@
+import GraphiQlForm from '@/components/graphiql-form/graphiql-form';
+
+export default function GraphiQL() {
+  return <GraphiQlForm />;
+}

--- a/src/components/graphiql-form/graphiql-form.module.css
+++ b/src/components/graphiql-form/graphiql-form.module.css
@@ -1,0 +1,24 @@
+.graphiql-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.graphiql-form input {
+  height: 40px;
+}
+
+.main-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.main-row div {
+  flex-grow: 1;
+}
+
+.graphiql-form input[type='submit'] {
+  font-size: inherit;
+  padding: 5px;
+}

--- a/src/components/graphiql-form/graphiql-form.tsx
+++ b/src/components/graphiql-form/graphiql-form.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import styles from './graphiql-form.module.css';
+import { usePathname } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useContext } from 'react';
+import { useForm } from 'react-hook-form';
+import LabeledInput from './labeled-input/labeled-input';
+import { GraphQlRequest, GraphQlUrlParams } from '@/types/graphql';
+import getDecodedStr from '@/utils/get-decoded-string';
+import { DictionaryContext } from '@/providers/dictionary-provider';
+import getLocale from '@/utils/get-locale';
+import getEncodedString from '@/utils/get-encoded-string';
+
+export default function GraphiQlForm({ params }: { params?: GraphQlUrlParams }) {
+  const { register, handleSubmit, watch } = useForm<GraphQlRequest>({
+    defaultValues: {
+      endpointUrl: params ? getDecodedStr(params.base64endpoint) : '',
+      query: params ? getDecodedStr(params.base64body) : '',
+    },
+  });
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const dictionary = useContext(DictionaryContext);
+  if (!dictionary) return;
+
+  const onSubmit = () => {
+    const locale = getLocale(pathname);
+    const endpoint = watch('endpointUrl');
+    const base64endpoint = getEncodedString(endpoint);
+    const body = watch('query');
+    const base64body = getEncodedString(body);
+
+    if (base64endpoint && base64body !== undefined) router.push(`/${locale}/GRAPHQL/${base64endpoint}/${base64body}`);
+  };
+
+  return (
+    <form
+      onSubmit={(event: FormEvent) => {
+        event.preventDefault();
+        void handleSubmit(onSubmit)();
+      }}
+      className={styles['graphiql-form']}
+    >
+      <div className={styles['main-row']}>
+        <LabeledInput field="endpointUrl" register={register} isRequired={true} />
+        <input type="submit" value={dictionary.send} />
+      </div>
+      <LabeledInput field="query" register={register} />
+    </form>
+  );
+}

--- a/src/components/graphiql-form/labeled-input/labeled-input.module.css
+++ b/src/components/graphiql-form/labeled-input/labeled-input.module.css
@@ -1,0 +1,14 @@
+.labeled-input {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.labeled-input label {
+  color: var(--color-label);
+}
+
+.labeled-input input {
+  padding: 10px;
+  font-size: inherit;
+}

--- a/src/components/graphiql-form/labeled-input/labeled-input.tsx
+++ b/src/components/graphiql-form/labeled-input/labeled-input.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import styles from './labeled-input.module.css';
+import { UseFormRegister } from 'react-hook-form';
+import { GraphQlRequest, GraphQlRequestField } from '@/types/graphql';
+import { useContext } from 'react';
+import { DictionaryContext } from '@/providers/dictionary-provider';
+
+export default function LabeledInput({
+  field,
+  register,
+  isRequired = false,
+}: {
+  field: GraphQlRequestField;
+  register: UseFormRegister<GraphQlRequest>;
+  isRequired?: boolean;
+}) {
+  const dictionary = useContext(DictionaryContext);
+  if (!dictionary) return;
+
+  return (
+    <div className={styles['labeled-input']}>
+      <label>
+        <p>{dictionary.graphql[field]}</p>
+      </label>
+      <input type="text" {...register(field)} required={isRequired}></input>
+    </div>
+  );
+}

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -1,0 +1,12 @@
+export type GraphQlRequest = {
+  endpointUrl: string;
+  query: string;
+};
+
+export type GraphQlRequestField = keyof GraphQlRequest;
+
+export type GraphQlUrlParams = {
+  lang: string;
+  base64endpoint: string;
+  base64body: string;
+};

--- a/src/utils/get-decoded-string.tsx
+++ b/src/utils/get-decoded-string.tsx
@@ -1,0 +1,9 @@
+export default function getDecodedStr(urlParam: string): string | undefined {
+  try {
+    const base64Str = urlParam.replaceAll('%3D', '=');
+    const decodedStr = atob(base64Str);
+    return decodedStr;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utils/get-encoded-string.tsx
+++ b/src/utils/get-encoded-string.tsx
@@ -1,0 +1,7 @@
+export default function getEncodedString(value: string): string | undefined {
+  try {
+    return btoa(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utils/get-locale.tsx
+++ b/src/utils/get-locale.tsx
@@ -1,0 +1,4 @@
+export default function getLocale(pathname: string): string {
+  const locale = pathname.split('/')[1];
+  return locale ? locale : '';
+}


### PR DESCRIPTION
#### Link to issue:	[link](https://github.com/users/tanykos/projects/1/views/1?pane=issue&itemId=76362320)																									
																									
#### Type of change:																									
																									
- [ ] Bug fix (a change which fixes an issue).																									
- [x] New feature (a change which adds functionality).																									
- [ ] Code refactor.																									
- [ ] Add/change styles.																									

#### Description																									
																									
<!-- Summarize the changes made and the problem or enhancement addressed. -->
Add GrapiQL form with two inputs: endpoint and query. Endpoint is required. Get inputs and send http request on form submit.																									
																									
#### Additional Information		
- You can check response with ```https://swapi-graphql.netlify.app/.netlify/functions/index``` endpoint and ```AllFilms { allFilms { totalCount } } ``` query.
- Fetch is used, want to switch to axios later.
- A query input is not yet an editor, but a text input.																	
																									
**Screenshots/Links:**	
![image](https://github.com/user-attachments/assets/c6d9f5cb-0b37-4836-8dbe-6cfee0c08a38)
																								
																									