### PR TITLE
fix: fix base64 encoding to be url safe

### DIFF
--- a/src/utils/get-decoded-string.tsx
+++ b/src/utils/get-decoded-string.tsx
@@ -1,6 +1,6 @@
-export default function getDecodedStr(urlParam: string): string | undefined {
+export default function getDecodedStr(base64Url: string): string | undefined {
   try {
-    const base64Str = urlParam.replaceAll('%3D', '=');
+    const base64Str = base64Url.replaceAll('_', '/').replaceAll('-', '+');
     const decodedStr = atob(base64Str);
     return decodedStr;
   } catch {

--- a/src/utils/get-encoded-string.tsx
+++ b/src/utils/get-encoded-string.tsx
@@ -1,6 +1,8 @@
 export default function getEncodedString(value: string): string | undefined {
   try {
-    return btoa(value);
+    const base64Str = btoa(value);
+    const base64Url = base64Str.replaceAll('/', '_').replace('+', '-');
+    return base64Url;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
#### Link to issue:																										
																									
#### Type of change:																									
																									
- [x] Bug fix (a change which fixes an issue).																									
- [ ] New feature (a change which adds functionality).																									
- [ ] Code refactor.																									
- [ ] Add/change styles.																									

#### Description																									
																									
<!-- Summarize the changes made and the problem or enhancement addressed. -->
Fix issue where not found page is shown if `/` is present in base64 values in the url.																								
																									
#### Additional Information		
From [MDN about Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64) :																							
![image](https://github.com/user-attachments/assets/8e3607a4-2dfd-47c0-a73f-5955c26f8992)
[RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-5)

																									
**Screenshots/Links:**																									
																									